### PR TITLE
Añadir organizadores

### DIFF
--- a/organizadores.txt
+++ b/organizadores.txt
@@ -1,0 +1,3 @@
+Paco
+Lola
+Hemrinia


### PR DESCRIPTION
La rama organizadores contiene un fichero con los difrenretes organizadores del proyecto. Se ha abierto esta rama porque al final del evento se proyectaŕan sus nombres y se les dará las gracias por su labor de organización.